### PR TITLE
MLOPS-506 Make tests pass on MacOS and with recent dependencies

### DIFF
--- a/ci/unit_tests.sh
+++ b/ci/unit_tests.sh
@@ -9,6 +9,7 @@ trap 'error=1' ERR
 GIT_ROOT=$(git rev-parse --show-toplevel)
 cd "$GIT_ROOT" || exit
 
+export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python
 python -m pytest tests --cov=bentoml --cov-config=.coveragerc --ignore tests/integration
 
 test $error = 0 # Return non-zero if pytest failed

--- a/setup.py
+++ b/setup.py
@@ -78,7 +78,7 @@ test_requires = [
     "codecov",
     "coverage>=4.4",
     "flake8>=3.8.2",
-    "imageio>=2.5.0",
+    "imageio>=2.5.0,<2.22.1",
     "mock>=2.0.0",
     "moto==1.3.14",
     "pandas",

--- a/tests/cli/test_cli.py
+++ b/tests/cli/test_cli.py
@@ -229,6 +229,7 @@ def test_gunicorn_serve_command():
             mb_max_batch_size=None,
             mb_max_latency=None,
             microbatch_workers=1,
+            daemon=True
         )
 
         runner.invoke(
@@ -254,6 +255,7 @@ def test_gunicorn_serve_command():
             mb_max_batch_size=10000,
             mb_max_latency=20000,
             microbatch_workers=5,
+            daemon=True
         )
 
 


### PR DESCRIPTION
Changes required to make the current tests in the master branch pass.

* Limited the imagio version - because of a breaking change in the recent version
* Added `export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python` to avoid installing c++ compiler
* Added `daemon=True` in gunicorn tests

<img width="720" alt="Screenshot 2022-12-05 at 09 04 48" src="https://user-images.githubusercontent.com/4731151/205585196-9db1b11b-7e3d-4568-a97e-2de9aa0948b4.png">

