### PR TITLE
[MLOPS560] [BentoML] BentoML returns a custom header to indicate the exception class

### DIFF
--- a/tests/server/test_model_api_server.py
+++ b/tests/server/test_model_api_server.py
@@ -96,6 +96,8 @@ def test_api_function_route(bento_bundle_path, img_file):
 
     assert 501 == response.status_code
     assert {"message": "test error message"} == response.json
+    assert 'X-Exception-Class' in response.headers
+    assert "InferenceException" == response.headers["X-Exception-Class"]
 
     # Disabling fastai related tests to fix travis build
     # response = test_client.post(


### PR DESCRIPTION
## Idea

BentoML implementation will return a custom header to indicate that the InferenceException was thrown to customize the response HTTP status and content. This will allow do distinguish between generic exceptions and model-specific exceptions. Finally, it allows to log them differently.

## Test results

<img width="914" alt="Screenshot 2022-12-27 at 21 58 54" src="https://user-images.githubusercontent.com/4731151/209716772-5d3b0e9d-2fb3-4f94-a976-7500366f21fd.png">
