### PR TITLE
[MLOPS-575] [BentoML] Log details of failed requests

### DIFF
--- a/bentoml/service/inference_api.py
+++ b/bentoml/service/inference_api.py
@@ -184,7 +184,7 @@ class InferenceAPI(object):
                             dict(
                                 log_data,
                                 task=task_to_log.to_json(),
-                                error=error_data,
+                                error_response=error_data,
                                 request_id=task_to_log.task_id,
                             )
                         )

--- a/bentoml/service/inference_api.py
+++ b/bentoml/service/inference_api.py
@@ -165,33 +165,32 @@ class InferenceAPI(object):
         except TypeError:
             pass
 
-    def log_errors_in_request(self, tasks, status_code: int, error_message: str, exception: Exception):
-        log_data = dict(
-            service_name=self.service.name if self.service else "",
-            service_version=self.service.version if self.service else "",
-            api=self.name,
-        )
-        error_data = dict(
-            status_code=status_code,
-            error_message=error_message,
-            exception_class=exception.__class__.__name__,
-        )
-        for task_to_log in tasks:
-            prediction_logger.error(
-                dict(
-                    log_data,
-                    task=task_to_log.to_json(),
-                    error_response=error_data,
-                    request_id=task_to_log.task_id,
-                )
-            )
-
         @functools.wraps(self._user_func)
         def wrapped_func(*args, **kwargs):
             def handle_error(tasks, status_code: int, error_message: str, exception: Exception):
+                def log_request():
+                    log_data = dict(
+                        service_name=self.service.name if self.service else "",
+                        service_version=self.service.version if self.service else "",
+                        api=self.name,
+                    )
+                    error_data = dict(
+                        status_code=status_code,
+                        error_message=error_message,
+                        exception_class=exception.__class__.__name__,
+                    )
+                    for task_to_log in tasks:
+                        prediction_logger.error(
+                            dict(
+                                log_data,
+                                task=task_to_log.to_json(),
+                                error_response=error_data,
+                                request_id=task_to_log.task_id,
+                            )
+                        )
                 logger.error("Error caught in API function:", exc_info=1)
                 exception_class_name = exception.__class__.__name__
-                self.log_errors_in_request(tasks, status_code, error_message, exception)
+                log_request()
                 if self.batch:
                     for task in tasks:
                         if not task.is_discarded:

--- a/bentoml/service/inference_api.py
+++ b/bentoml/service/inference_api.py
@@ -190,6 +190,7 @@ class InferenceAPI(object):
                         )
                 logger.error("Error caught in API function:", exc_info=1)
                 exception_class_name = exception.__class__.__name__
+                log_request()
                 if self.batch:
                     for task in tasks:
                         if not task.is_discarded:
@@ -198,7 +199,6 @@ class InferenceAPI(object):
                                 err_msg=error_message,
                                 err_class=exception_class_name,
                             )
-                    log_request()
                     return [None] * sum(
                         1 if t.batch is None else t.batch for t in tasks
                     )
@@ -210,7 +210,6 @@ class InferenceAPI(object):
                             err_msg=error_message,
                             err_class=exception_class_name,
                         )
-                    log_request()
                     return [None] * (1 if task.batch is None else task.batch)
             with self.tracer.span(
                     service_name=f"BentoService.{self.service.name}",

--- a/bentoml/service/inference_api.py
+++ b/bentoml/service/inference_api.py
@@ -165,32 +165,33 @@ class InferenceAPI(object):
         except TypeError:
             pass
 
+    def log_errors_in_request(self, tasks, status_code: int, error_message: str, exception: Exception):
+        log_data = dict(
+            service_name=self.service.name if self.service else "",
+            service_version=self.service.version if self.service else "",
+            api=self.name,
+        )
+        error_data = dict(
+            status_code=status_code,
+            error_message=error_message,
+            exception_class=exception.__class__.__name__,
+        )
+        for task_to_log in tasks:
+            prediction_logger.error(
+                dict(
+                    log_data,
+                    task=task_to_log.to_json(),
+                    error_response=error_data,
+                    request_id=task_to_log.task_id,
+                )
+            )
+
         @functools.wraps(self._user_func)
         def wrapped_func(*args, **kwargs):
             def handle_error(tasks, status_code: int, error_message: str, exception: Exception):
-                def log_request():
-                    log_data = dict(
-                        service_name=self.service.name if self.service else "",
-                        service_version=self.service.version if self.service else "",
-                        api=self.name,
-                    )
-                    error_data = dict(
-                        status_code=status_code,
-                        error_message=error_message,
-                        exception_class=exception.__class__.__name__,
-                    )
-                    for task_to_log in tasks:
-                        prediction_logger.error(
-                            dict(
-                                log_data,
-                                task=task_to_log.to_json(),
-                                error_response=error_data,
-                                request_id=task_to_log.task_id,
-                            )
-                        )
                 logger.error("Error caught in API function:", exc_info=1)
                 exception_class_name = exception.__class__.__name__
-                log_request()
+                self.log_errors_in_request(tasks, status_code, error_message, exception)
                 if self.batch:
                     for task in tasks:
                         if not task.is_discarded:


### PR DESCRIPTION
## BentoML test results:

<img width="724" alt="Screenshot 2022-12-29 at 14 44 04" src="https://user-images.githubusercontent.com/4731151/209952787-0e78c564-ae3f-46c0-96d3-df4cd513f7cc.png">

## Qwak API test results:

When the request fails, it gets logged with request/response details:

```
[2022-12-29 13:31:56,817] ERROR - {'service_name': 'QwakBentoml', 'service_version': '20221229133125_367386', 'api': 'predict', 'task': {'data': '{"columns":["exception"],"index":[0],"data":[[2]]}', 'error': {'err_msg': 'Exception happened in API function: This is a test exception', 'http_headers': (('X-Exception-Class', 'ValueError'),)}, 'task_id': '383bcc90-50b4-4250-b9a1-9e6e54d2cffd', 'is_discarded': True, 'batch': 1, 'http_headers': (('Host', '127.0.0.1:33559'), ('User-Agent', 'python-requests/2.28.1'), ('Accept-Encoding', 'gzip, deflate, br'), ('Accept', '*/*'), ('Connection', 'keep-alive'), ('Content-Type', 'application/json'), ('Authorization', 'Bearer ...'), ('X-Test-Case', 'test_failure_inside_predict'), ('x-realtime-route-mode', 'true'), ('Content-Length', '50'))}, 'error_response': {'status_code': 500, 'error_message': 'Exception happened in API function: This is a test exception', 'exception_class': 'ValueError'}, 'request_id': '383bcc90-50b4-4250-b9a1-9e6e54d2cffd'}
```

<img width="926" alt="Screenshot 2022-12-29 at 15 34 14" src="https://user-images.githubusercontent.com/4731151/209961236-25809099-e9f4-4976-86a7-63c6e7c3a932.png">
